### PR TITLE
Add placeholder SCSS for theme

### DIFF
--- a/_sass/just-the-docs.scss
+++ b/_sass/just-the-docs.scss
@@ -1,0 +1,1 @@
+/* placeholder for just-the-docs theme */


### PR DESCRIPTION
## Summary
- add a minimal `_sass/just-the-docs.scss` so Jekyll finds the import

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886ae3f8470832f9f3ca2469f5bf1b3