### PR TITLE
Fix SCSS import for just-the-docs theme

### DIFF
--- a/_sass/just-the-docs.scss
+++ b/_sass/just-the-docs.scss
@@ -1,1 +1,0 @@
-/* placeholder for just-the-docs theme */

--- a/assets/css/just-the-docs-default.scss
+++ b/assets/css/just-the-docs-default.scss
@@ -1,5 +1,8 @@
 ---
 ---
-
-@import "just-the-docs";
-@import "custom/custom";
+{% if site.color_scheme and site.color_scheme != "nil" %}
+  {% assign color_scheme = site.color_scheme %}
+{% else %}
+  {% assign color_scheme = "light" %}
+{% endif %}
+{% include css/just-the-docs.scss.liquid color_scheme=color_scheme %}


### PR DESCRIPTION
## Summary
- remove placeholder `just-the-docs.scss`
- replace custom stylesheet with the theme's default `just-the-docs` include

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6886bcc63704832faeae50a12d5dab28